### PR TITLE
Support AWS Provider V5

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
       - 'examples/**'
       - 'test/**'
+      - 'README.*'
 
 permissions:
   contents: write

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   terraform-module:
-    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release.yml@main
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-published.yml@main

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,20 +3,20 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "cloudposse/vpc/aws"
-  version    = "0.18.0"
-  cidr_block = var.vpc_cidr_block
-  context    = module.this.context
+  source                  = "cloudposse/vpc/aws"
+  version                 = "2.1.0"
+  ipv4_primary_cidr_block = var.vpc_cidr_block
+  context                 = module.this.context
 }
 
 module "subnets" {
   source               = "cloudposse/dynamic-subnets/aws"
-  version              = "0.32.0"
+  version              = "2.3.0"
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id
-  igw_id               = module.vpc.igw_id
-  cidr_block           = module.vpc.vpc_cidr_block
-  nat_gateway_enabled  = true
+  igw_id               = [module.vpc.igw_id]
+  ipv4_cidr_block      = [module.vpc.vpc_cidr_block]
+  nat_gateway_enabled  = false
   nat_instance_enabled = false
   context              = module.this.context
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "scale_up_policy_arn" {
   description = "ARN of the scale up policy"
-  value       = join("", aws_appautoscaling_policy.up.*.arn)
+  value       = join("", aws_appautoscaling_policy.up[*].arn)
 }
 
 output "scale_down_policy_arn" {
   description = "ARN of the scale down policy"
-  value       = join("", aws_appautoscaling_policy.down.*.arn)
+  value       = join("", aws_appautoscaling_policy.down[*].arn)
 }


### PR DESCRIPTION
## what

Support AWS Provider V5
Linter fixes

## why

Maintenance

## references

https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.0.0
