### PR TITLE
fix: adds tags for AS policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ resource "aws_appautoscaling_target" "default" {
   scalable_dimension = "ecs:service:DesiredCount"
   min_capacity       = var.min_capacity
   max_capacity       = var.max_capacity
+  tags               = module.this.tags
 }
 
 resource "aws_appautoscaling_policy" "up" {


### PR DESCRIPTION
## what

- Adds tags for Autoscaling Policy resource.

## why

- `aws_appautoscaling_target` resource supports tags but they are not set in the module.

## references

- closes https://github.com/cloudposse/terraform-aws-ecs-cloudwatch-autoscaling/issues/40
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target#tags

⚠️ This is not a breaking change, but we need to bump the major version as vars were removed + added in the previous release: [v0.7.6](https://github.com/cloudposse/terraform-aws-ecs-cloudwatch-autoscaling/releases/tag/v0.7.6).
